### PR TITLE
Add NestJS server and basic React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a simple **NestJS** backend and a **React** frontend.
 
 ## Server
 
-The `server` folder holds a minimal NestJS application. Run `npm run build` to compile TypeScript and `npm start` to start the server after installing dependencies.
+The `server` folder holds a minimal NestJS application. After running `npm install` to install dependencies, run `npm run build` to compile TypeScript and `npm start` to start the server.
 
 ## Client
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
+# Project Assignment
 
+This repository contains a simple **NestJS** backend and a **React** frontend.
+
+## Server
+
+The `server` folder holds a minimal NestJS application. Run `npm run build` to compile TypeScript and `npm start` to start the server after installing dependencies.
+
+## Client
+
+The `client` folder holds a basic React application bundled with webpack. After installing dependencies you can run `npm start` to serve the frontend.

--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "client",
+  "version": "1.0.0",
+  "description": "React frontend",
+  "main": "index.js",
+  "scripts": {
+    "start": "webpack serve --mode development --open",
+    "build": "webpack --mode production"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "webpack": "^5.0.0",
+    "webpack-cli": "^5.0.0",
+    "webpack-dev-server": "^4.0.0",
+    "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^9.0.0"
+  }
+}

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>React App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="/bundle.js"></script>
+  </body>
+</html>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function App() {
+  return <div></div>;
+}

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,0 +1,29 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.jsx',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+        },
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'public'),
+    },
+    port: 3001,
+  },
+};

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.5.0"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "NestJS server",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/main.js"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.5.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/node": "^18.0.0"
+  }
+}

--- a/server/src/app.controller.ts
+++ b/server/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getHello(): string {
+    return this.appService.getHello();
+  }
+}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+@Module({
+  imports: [],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/server/src/app.service.ts
+++ b/server/src/app.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHello(): string {
+    return 'Hello World!';
+  }
+}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2018",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "incremental": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add a minimal NestJS backend in `server`
- add a basic React frontend in `client`
- document how to run both applications

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686f9bc5c5fc83228a9ef6227c5e38d3