### PR TITLE
Add MSSQL connection to NestJS server

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,8 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.5.0"
+    "rxjs": "^7.5.0",
+    "mssql": "^10.0.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/server/src/app.controller.ts
+++ b/server/src/app.controller.ts
@@ -6,7 +6,7 @@ export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
-  getHello(): string {
+  getHello(): Promise<string> {
     return this.appService.getHello();
   }
 }

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { databaseProvider } from './database.provider';
 
 @Module({
   imports: [],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, databaseProvider],
 })
 export class AppModule {}

--- a/server/src/app.service.ts
+++ b/server/src/app.service.ts
@@ -1,8 +1,14 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
+import { ConnectionPool } from 'mssql';
 
 @Injectable()
 export class AppService {
-  getHello(): string {
-    return 'Hello World!';
+  constructor(
+    @Inject('MSSQL_CONNECTION') private readonly db: ConnectionPool,
+  ) {}
+
+  async getHello(): Promise<string> {
+    const result = await this.db.request().query("SELECT 'Hello World!' as message");
+    return result.recordset[0].message;
   }
 }

--- a/server/src/database.provider.ts
+++ b/server/src/database.provider.ts
@@ -1,0 +1,19 @@
+import { Provider } from '@nestjs/common';
+import * as sql from 'mssql';
+
+export const databaseProvider: Provider = {
+  provide: 'MSSQL_CONNECTION',
+  useFactory: async () => {
+    const config: sql.config = {
+      user: process.env.DB_USER || 'sa',
+      password: process.env.DB_PASSWORD || 'yourStrong(!)Password',
+      server: process.env.DB_SERVER || 'localhost',
+      database: process.env.DB_NAME || 'master',
+      options: {
+        encrypt: false,
+        trustServerCertificate: true,
+      },
+    };
+    return sql.connect(config);
+  },
+};


### PR DESCRIPTION
## Summary
- install `mssql` dependency for the server
- create a database provider that connects to MSSQL using environment variables
- inject the connection into the app service and query a hello message
- expose the async result from the controller

## Testing
- `npm install` *(fails: access to registry is blocked)*
- `npm run build` *(fails: dependencies missing due to install failure)*

------
https://chatgpt.com/codex/tasks/task_b_686fb102d40c83228f3509473e8fbd6d