### PR TITLE
Add workdays table component

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"]
+  "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-typescript"]
 }

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
-    "babel-loader": "^9.0.0"
+    "babel-loader": "^9.0.0",
+    "@babel/preset-typescript": "^7.0.0"
   }
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,10 @@
 import React from 'react';
+import WorkdaysTable from './WorkdaysTable';
 
 export default function App() {
-  return <div></div>;
+  return (
+    <div>
+      <WorkdaysTable />
+    </div>
+  );
 }

--- a/client/src/WorkdaysTable.tsx
+++ b/client/src/WorkdaysTable.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+
+interface Holiday {
+  date: string;
+}
+
+const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+export default function WorkdaysTable() {
+  const now = new Date();
+  const [year, setYear] = useState<number>(now.getFullYear());
+  const [month, setMonth] = useState<number>(now.getMonth() + 1); // 1-12
+  const [holidays, setHolidays] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    fetch(`https://date.nager.at/api/v3/PublicHolidays/${year}/IL`)
+      .then((res) => res.json())
+      .then((data: Holiday[]) => {
+        const dates = new Set<string>(data.map((h) => h.date));
+        setHolidays(dates);
+      })
+      .catch(() => setHolidays(new Set()));
+  }, [year]);
+
+  const daysInMonth = new Date(year, month, 0).getDate();
+  const rows: JSX.Element[] = [];
+  for (let d = 1; d <= daysInMonth; d++) {
+    const dateObj = new Date(year, month - 1, d);
+    const dateStr = dateObj.toISOString().split('T')[0];
+    if (holidays.has(dateStr)) {
+      continue;
+    }
+    const dayIndex = dateObj.getDay();
+    const dayName = weekdays[dayIndex];
+    let hours = 0;
+    if (dayIndex >= 0 && dayIndex <= 3) {
+      hours = 9;
+    } else if (dayIndex === 4) {
+      hours = 8;
+    }
+    rows.push(
+      <tr key={dateStr}>
+        <td>{dateStr}</td>
+        <td>{dayName}</td>
+        <td>{hours}</td>
+      </tr>
+    );
+  }
+
+  return (
+    <div>
+      <div style={{ marginBottom: '10px' }}>
+        <select value={month} onChange={(e) => setMonth(parseInt(e.target.value, 10))}>
+          {Array.from({ length: 12 }, (_, i) => i + 1).map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+        <select value={year} onChange={(e) => setYear(parseInt(e.target.value, 10))}>
+          {Array.from({ length: 5 }, (_, i) => now.getFullYear() - 2 + i).map((y) => (
+            <option key={y} value={y}>
+              {y}
+            </option>
+          ))}
+        </select>
+      </div>
+      <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+        <thead>
+          <tr>
+            <th style={{ border: '1px solid #ccc', padding: '4px' }}>Date</th>
+            <th style={{ border: '1px solid #ccc', padding: '4px' }}>Day</th>
+            <th style={{ border: '1px solid #ccc', padding: '4px' }}>Planned Hours</th>
+          </tr>
+        </thead>
+        <tbody>{rows}</tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.(js|jsx)$/,
+        test: /\.(js|jsx|ts|tsx)$/,
         exclude: /node_modules/,
         use: {
           loader: 'babel-loader',
@@ -18,7 +18,7 @@ module.exports = {
     ],
   },
   resolve: {
-    extensions: ['.js', '.jsx'],
+    extensions: ['.ts', '.tsx', '.js', '.jsx'],
   },
   devServer: {
     static: {


### PR DESCRIPTION
## Summary
- set up Babel for TypeScript
- add WorkdaysTable component with month/year selectors
- render WorkdaysTable in App

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686fc7c64b84832280b710cd9a3c3006