### PR TITLE
Add TypeORM working days controller

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,10 @@
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.4.19",
+    "@nestjs/typeorm": "^10.0.0",
     "mssql": "^10.0.0",
+    "typeorm": "^0.3.17",
+    "uuid": "^9.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.5.0"
   },

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,13 +1,29 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { databaseProvider } from './database.provider';
-import {ConfigModule} from "@nestjs/config";
+import { WorkingDaysModule } from './working-days/working-days.module';
 
 @Module({
-  imports: [ConfigModule.forRoot({
-    isGlobal: true, // optional but useful
-  })],
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    TypeOrmModule.forRoot({
+      type: 'mssql',
+      host: process.env.DB_SERVER || 'localhost',
+      username: process.env.DB_USER || 'sa',
+      password: process.env.DB_PASSWORD || 'yourStrong(!)Password',
+      database: process.env.DB_NAME || 'master',
+      synchronize: false,
+      entities: [__dirname + '/**/*.entity{.ts,.js}'],
+      options: {
+        encrypt: true,
+        trustServerCertificate: true,
+      },
+    }),
+    WorkingDaysModule,
+  ],
   controllers: [AppController],
   providers: [AppService, databaseProvider],
 })

--- a/server/src/migrations/1692289000000-CreateWorkingDays.ts
+++ b/server/src/migrations/1692289000000-CreateWorkingDays.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateWorkingDays1692289000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'working_days',
+        columns: [
+          {
+            name: 'id',
+            type: 'uniqueidentifier',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'NEWID()',
+          },
+          {
+            name: 'date',
+            type: 'date',
+            isUnique: true,
+          },
+          {
+            name: 'day_of_week',
+            type: 'varchar',
+          },
+          {
+            name: 'working_hours',
+            type: 'decimal',
+            precision: 4,
+            scale: 2,
+          },
+          {
+            name: 'is_holiday',
+            type: 'bit',
+          },
+          {
+            name: 'created_at',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updated_at',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('working_days');
+  }
+}

--- a/server/src/working-days/dto/working-day.dto.ts
+++ b/server/src/working-days/dto/working-day.dto.ts
@@ -1,0 +1,5 @@
+export class WorkingDayDto {
+  date: string; // YYYY-MM-DD
+  working_hours: number;
+  is_holiday: boolean;
+}

--- a/server/src/working-days/working-day.entity.ts
+++ b/server/src/working-days/working-day.entity.ts
@@ -1,0 +1,25 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity({ name: 'working_days' })
+export class WorkingDay {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'date', unique: true })
+  date: string;
+
+  @Column()
+  day_of_week: string;
+
+  @Column({ type: 'decimal', precision: 4, scale: 2 })
+  working_hours: number;
+
+  @Column({ type: 'bit' })
+  is_holiday: boolean;
+
+  @Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+
+  @Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' })
+  updated_at: Date;
+}

--- a/server/src/working-days/working-days.controller.ts
+++ b/server/src/working-days/working-days.controller.ts
@@ -1,0 +1,19 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { WorkingDaysService } from './working-days.service';
+import { WorkingDayDto } from './dto/working-day.dto';
+
+@Controller('working-days')
+export class WorkingDaysController {
+  constructor(private readonly service: WorkingDaysService) {}
+
+  @Post()
+  createOrUpdate(@Body() dto: WorkingDayDto) {
+    return this.service.createOrUpdate(dto);
+  }
+
+  @Post('bulk')
+  async replaceMonth(@Body() dtos: WorkingDayDto[]) {
+    await this.service.replaceMonth(dtos);
+    return { success: true };
+  }
+}

--- a/server/src/working-days/working-days.module.ts
+++ b/server/src/working-days/working-days.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WorkingDay } from './working-day.entity';
+import { WorkingDaysService } from './working-days.service';
+import { WorkingDaysController } from './working-days.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([WorkingDay])],
+  controllers: [WorkingDaysController],
+  providers: [WorkingDaysService],
+})
+export class WorkingDaysModule {}

--- a/server/src/working-days/working-days.service.ts
+++ b/server/src/working-days/working-days.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WorkingDay } from './working-day.entity';
+import { WorkingDayDto } from './dto/working-day.dto';
+
+@Injectable()
+export class WorkingDaysService {
+  constructor(
+    @InjectRepository(WorkingDay)
+    private readonly repo: Repository<WorkingDay>,
+  ) {}
+
+  async createOrUpdate(dto: WorkingDayDto): Promise<WorkingDay> {
+    const day = await this.repo.findOne({ where: { date: dto.date } });
+    const entity = this.repo.merge(
+      day || new WorkingDay(),
+      {
+        ...dto,
+        day_of_week: new Date(dto.date).toLocaleDateString('en-US', {
+          weekday: 'long',
+        }),
+      },
+    );
+    return this.repo.save(entity);
+  }
+
+  async replaceMonth(entries: WorkingDayDto[]): Promise<void> {
+    if (entries.length === 0) return;
+    const month = entries[0].date.slice(0, 7);
+    await this.repo
+      .createQueryBuilder()
+      .delete()
+      .where('date LIKE :month', { month: `${month}-%` })
+      .execute();
+    for (const dto of entries) {
+      await this.createOrUpdate(dto);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- integrate TypeORM with MSSQL
- add working days entity, service, controller, and module
- create TypeORM migration for working_days table
- expose endpoints for single day save and monthly bulk replace

## Testing
- `npm run build` *(fails: Cannot find module due to missing dependencies)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686fc853cda483228eaa311913aece74