### PR TITLE
Enable TypeORM migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+server/dist/
+client/dist/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a simple **NestJS** backend and a **React** frontend.
 
 ## Server
 
-The `server` folder holds a minimal NestJS application. After running `npm install` to install dependencies, run `npm run build` to compile TypeScript and `npm start` to start the server.
+The `server` folder holds a minimal NestJS application. After running `npm install` to install dependencies, run `npm run build` to compile TypeScript. Before starting the server you may need to run database migrations using `npm run migration:run`. Finally start the server with `npm start`.
 
 ## Client
 

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "main": "dist/main.js",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/main.js"
+    "start": "node dist/main.js",
+    "migration:run": "ts-node ./node_modules/typeorm/cli.js migration:run -d src/data-source.ts"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
@@ -21,6 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "ts-node": "^10.0.0"
   }
 }

--- a/server/src/data-source.ts
+++ b/server/src/data-source.ts
@@ -1,0 +1,17 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+
+export const AppDataSource = new DataSource({
+  type: 'mssql',
+  host: process.env.DB_SERVER || 'localhost',
+  username: process.env.DB_USER || 'sa',
+  password: process.env.DB_PASSWORD || 'yourStrong(!)Password',
+  database: process.env.DB_NAME || 'master',
+  synchronize: false,
+  entities: [__dirname + '/**/*.entity{.ts,.js}'],
+  migrations: [__dirname + '/migrations/*{.ts,.js}'],
+  options: {
+    encrypt: true,
+    trustServerCertificate: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add a generic `.gitignore`
- create a TypeORM data source for MSSQL
- include `ts-node` and a `migration:run` script
- update README with migration instructions

## Testing
- `npm -C server run build` *(fails: Cannot find module '@nestjs/common')*
- `npm -C server run migration:run` *(fails: ts-node: not found)*

------
https://chatgpt.com/codex/tasks/task_b_686fd28f261c8322818f2d2dc72e6835