### PR TITLE
Improve calendar layout

### DIFF
--- a/client/src/WorkdaysTable.tsx
+++ b/client/src/WorkdaysTable.tsx
@@ -14,22 +14,48 @@ interface Props {
 const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu'];
 
 export default function WorkdaysTable({ year, month, data }: Props) {
-  const daysInMonth = new Date(year, month, 0).getDate();
+  const [selectedYear, setSelectedYear] = React.useState(year);
+  const [selectedMonth, setSelectedMonth] = React.useState(month);
+
+  const daysInMonth = new Date(selectedYear, selectedMonth, 0).getDate();
+
   const dataMap = React.useMemo(() => {
     const map = new Map<string, number>();
     for (const item of data) {
-      map.set(item.date, item.workingHours);
+      const [y, m] = item.date.split('-').map(Number);
+      if (y === selectedYear && m === selectedMonth) {
+        map.set(item.date, item.workingHours);
+      }
     }
     return map;
-  }, [data]);
+  }, [data, selectedMonth, selectedYear]);
 
   const todayStr = new Date().toISOString().split('T')[0];
+
+  const monthNames = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+
+  const years = React.useMemo(() => {
+    return Array.from({ length: 5 }, (_, i) => year - 2 + i);
+  }, [year]);
 
   const weeks: JSX.Element[] = [];
   let currentWeek: (JSX.Element | null)[] = new Array(5).fill(null);
 
   for (let d = 1; d <= daysInMonth; d++) {
-    const dateObj = new Date(year, month - 1, d);
+    const dateObj = new Date(selectedYear, selectedMonth - 1, d);
     const dateStr = dateObj.toISOString().split('T')[0];
     const dow = dateObj.getDay();
     if (dow >= 5) continue; // skip Fri & Sat
@@ -44,22 +70,33 @@ export default function WorkdaysTable({ year, month, data }: Props) {
     }
 
     const hours = dataMap.get(dateStr) ?? 0;
-    const display = hours === 4 ? '½d' : hours;
+    const display = hours === 4 ? '½d' : hours || '';
     const isToday = dateStr === todayStr;
+
+    let bg: string | undefined;
+    if (isToday) bg = '#ffeeba';
+    else if (hours >= 8) bg = '#f0f0f0';
+    else if (hours === 4) bg = '#d1ecf1';
+    else if (hours === 0) bg = '#f8d7da';
 
     currentWeek[dow] = (
       <div
         key={dateStr}
         style={{
-          border: '1px solid #ccc',
-          padding: '4px',
+          border: '1px solid #ddd',
+          padding: '6px',
+          minHeight: '60px',
           textAlign: 'center',
-          color: hours === 0 ? '#888' : undefined,
-          background: isToday ? '#ffeeba' : undefined,
+          background: bg,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          fontSize: '14px',
         }}
       >
-        <div>{d}</div>
-        <div>{display}</div>
+        <div style={{ fontWeight: 'bold' }}>{d}</div>
+        <div style={{ fontSize: '0.8em', color: '#555' }}>{display}</div>
       </div>
     );
 
@@ -82,19 +119,51 @@ export default function WorkdaysTable({ year, month, data }: Props) {
   }
 
   return (
-    <div
-      style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(5, 1fr)',
-        gap: '4px',
-      }}
-    >
-      {weekdays.map((w) => (
-        <div key={w} style={{ fontWeight: 'bold', textAlign: 'center' }}>
-          {w}
-        </div>
-      ))}
-      {weeks}
+    <div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          gap: '8px',
+          marginBottom: '8px',
+        }}
+      >
+        <select
+          value={selectedMonth}
+          onChange={(e) => setSelectedMonth(Number(e.target.value))}
+        >
+          {monthNames.map((m, idx) => (
+            <option key={m} value={idx + 1}>
+              {m}
+            </option>
+          ))}
+        </select>
+        <select
+          value={selectedYear}
+          onChange={(e) => setSelectedYear(Number(e.target.value))}
+        >
+          {years.map((y) => (
+            <option key={y} value={y}>
+              {y}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(5, 1fr)',
+          gap: '4px',
+        }}
+      >
+        {weekdays.map((w) => (
+          <div key={w} style={{ fontWeight: 'bold', textAlign: 'center' }}>
+            {w}
+          </div>
+        ))}
+        {weeks}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- enhance `WorkdaysTable` with month/year selectors
- style day cells in a calendar grid with color coded hours

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_b_686fd3df082c8322bb6b14a65317a0b5