### PR TITLE
Add total hours summary row

### DIFF
--- a/client/src/WorkdaysTable.tsx
+++ b/client/src/WorkdaysTable.tsx
@@ -50,6 +50,11 @@ export default function WorkdaysTable() {
     return map;
   }, [data]);
 
+  const totalHours = React.useMemo(
+      () => data.reduce((sum, d) => sum + d.workingHours, 0),
+      [data]
+  );
+
   const daysInMonth = new Date(selectedYear, selectedMonth, 0).getDate();
   const weeks: JSX.Element[] = [];
   let currentWeek: (JSX.Element | null)[] = new Array(5).fill(null);
@@ -155,6 +160,9 @@ export default function WorkdaysTable() {
               </div>
           ))}
           {weeks}
+        </div>
+        <div style={{ marginTop: '8px', fontWeight: 'bold', textAlign: 'right' }}>
+          Total: {totalHours} hours
         </div>
       </div>
   );


### PR DESCRIPTION
## Summary
- compute total working hours for the selected month
- show the monthly total below the calendar grid

## Testing
- `npm run build` in `client` *(fails: webpack not found)*
- `npm run build` in `server` *(fails: cannot find module '@nestjs/common')*

------
https://chatgpt.com/codex/tasks/task_b_686fdec431788322bb7f14b965750dc2