### PR TITLE
Add HarvestService to Nest backend

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,8 @@
     "typeorm": "^0.3.17",
     "uuid": "^9.0.0",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.5.0"
+    "rxjs": "^7.5.0",
+    "axios": "^1.6.0"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { databaseProvider } from './database.provider';
 import { WorkingDaysModule } from './working-days/working-days.module';
+import { HarvestService } from './harvest/harvest.service';
 
 @Module({
   imports: [
@@ -25,6 +26,6 @@ import { WorkingDaysModule } from './working-days/working-days.module';
     WorkingDaysModule,
   ],
   controllers: [AppController],
-  providers: [AppService, databaseProvider],
+  providers: [AppService, databaseProvider, HarvestService],
 })
 export class AppModule {}

--- a/server/src/constants/db.constants.ts
+++ b/server/src/constants/db.constants.ts
@@ -1,0 +1,16 @@
+export const API_ENDPOINTS = {
+  BASE_URL: '',
+  LOGIN: {
+    LOGIN: '/login',
+    GOOGLE: '/login/google',
+    CHECK_TOKEN: '/login/check-token',
+  },
+  WORK: {
+    TIME_LOGGED_BY_DATES: '/work/time-logged',
+    MAINTENANCE: '/work/maintenance',
+    PLANvsACTUAL: '/work/plan-vs-actual',
+  },
+  DATA: {
+    PROJECTS: '/data/projects',
+  },
+};

--- a/server/src/harvest/harvest.service.ts
+++ b/server/src/harvest/harvest.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+import Axios from 'axios';
+import { API_ENDPOINTS } from '../constants/db.constants';
+import { IPlanActualProject, IProjectsData } from '../types';
+
+@Injectable()
+export class HarvestService {
+  private _token?: string;
+  private headers?: { Authorization: string };
+
+  static async login(body: { userName: string; password: string }): Promise<string> {
+    const url = `${API_ENDPOINTS.BASE_URL}${API_ENDPOINTS.LOGIN.LOGIN}`;
+    const result = await Axios.post(url, body);
+    return result.data.token;
+  }
+
+  static async googleLogin(googleToken: string): Promise<string> {
+    const url = `${API_ENDPOINTS.BASE_URL}${API_ENDPOINTS.LOGIN.GOOGLE}`;
+    const result = await Axios.post(url, { googleToken });
+    return result.data.token;
+  }
+
+  set token(value: string) {
+    this._token = value;
+    this.headers = {
+      Authorization: `Bearer ${this._token}`,
+    };
+  }
+
+  protected get(endpoint: string, params: any = {}) {
+    const url = `${API_ENDPOINTS.BASE_URL}${endpoint}`;
+    return Axios.get(url, {
+      headers: this.headers,
+      params,
+    });
+  }
+
+  async getTimeLogged(year: number, month: number) {
+    const result = await this.get(API_ENDPOINTS.WORK.TIME_LOGGED_BY_DATES, { year, month });
+    return result.data;
+  }
+
+  async getMaintenance(year: number, month: number) {
+    const result = await this.get(API_ENDPOINTS.WORK.MAINTENANCE, { year, month });
+    return result.data.projects;
+  }
+
+  async getPlanVsActual(year: number, month: number): Promise<IPlanActualProject[]> {
+    const result = await this.get(API_ENDPOINTS.WORK.PLANvsACTUAL, { year, month });
+    return result.data.projects;
+  }
+
+  async checkToken(token: string): Promise<boolean> {
+    this._token = token;
+    try {
+      await this.get(API_ENDPOINTS.LOGIN.CHECK_TOKEN);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getProjects(month: number): Promise<IProjectsData> {
+    const now = new Date();
+    const result = await this.get(API_ENDPOINTS.DATA.PROJECTS, { month, year: now.getFullYear() });
+    return {
+      projects: result.data,
+    };
+  }
+}

--- a/server/src/types/index.ts
+++ b/server/src/types/index.ts
@@ -1,0 +1,7 @@
+export interface IPlanActualProject {
+  [key: string]: any;
+}
+
+export interface IProjectsData {
+  projects: any;
+}


### PR DESCRIPTION
## Summary
- create HarvestService in NestJS backend
- define API endpoint constants and types
- register HarvestService in AppModule
- add axios dependency

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: cannot find module '@nestjs/common' and others)*

------
https://chatgpt.com/codex/tasks/task_b_687343e17ccc8322a29e54ea147eabd9