### PR TITLE
Add header and footer with One Digital logo

### DIFF
--- a/client/public/one-digital-logo.svg
+++ b/client/public/one-digital-logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40">
+  <text x="0" y="30" font-size="30" font-family="Arial" fill="black">One Digital</text>
+</svg>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import ResourceMatrix from './ResourceMatrix';
+import Header from './Header';
+import Footer from './Footer';
 
 export default function App() {
   return (
     <div>
+      <Header />
       <ResourceMatrix />
+      <Footer />
     </div>
   );
 }

--- a/client/src/Footer.tsx
+++ b/client/src/Footer.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const footerStyle: React.CSSProperties = {
+  height: '60px',
+  background: '#f8f8f8',
+};
+
+export default function Footer() {
+  return <footer style={footerStyle}></footer>;
+}

--- a/client/src/Header.tsx
+++ b/client/src/Header.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+const headerStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  background: '#f8f8f8',
+  padding: '10px 20px',
+};
+
+const navStyle: React.CSSProperties = {
+  listStyle: 'none',
+  display: 'flex',
+  gap: '1rem',
+  margin: 0,
+  padding: 0,
+};
+
+const logoStyle: React.CSSProperties = {
+  height: '40px',
+};
+
+export default function Header() {
+  return (
+    <header style={headerStyle}>
+      <img src="/one-digital-logo.svg" alt="One Digital logo" style={logoStyle} />
+      <nav>
+        <ul style={navStyle}>
+          <li>Monthly plan</li>
+          <li>Weekly plan</li>
+          <li>Harvest</li>
+        </ul>
+      </nav>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- create black-and-white One Digital logo SVG
- add Header and Footer components
- display Header and Footer in `App`

## Testing
- `npm run build` *(fails: webpack not found)*
- `npm install` *(fails: no internet access)*

------
https://chatgpt.com/codex/tasks/task_b_68734469a5008322952e97137747a801