### PR TITLE
Add Swagger setup for server

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains a simple **NestJS** backend and a **React** frontend.
 The `server` folder holds a minimal NestJS application. After running `npm install` to install dependencies, run `npm run build` to compile TypeScript. Before starting the server you may need to run database migrations using `npm run migration:run`. Finally start the server with `npm start`.
 
 The server listens on the port defined by the `PORT` environment variable (default `3001`). You can copy `server/.env.example` to `.env` and adjust if needed.
+When the server is running, Swagger API documentation is available at `http://localhost:3001/api` by default.
 
 ## Client
 

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,9 @@
     "uuid": "^9.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.5.0",
-    "axios": "^1.6.0"
+    "axios": "^1.6.0",
+    "@nestjs/swagger": "^7.0.0",
+    "swagger-ui-express": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,8 +1,16 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  const swaggerConfig = new DocumentBuilder()
+    .setTitle('API')
+    .setDescription('Project API documentation')
+    .setVersion('1.0')
+    .build();
+  const document = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup('api', app, document);
   const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3001;
   await app.listen(port);
   console.log(`Server listening on port ${port}`);


### PR DESCRIPTION
## Summary
- add Swagger dependencies to the server
- expose documentation via `SwaggerModule` in `main.ts`
- document the Swagger endpoint in README

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_687352096d78832295f76867e281e514