### PR TITLE
Fetch team members for ResourceMatrix

### DIFF
--- a/client/src/HarvestStore.ts
+++ b/client/src/HarvestStore.ts
@@ -1,37 +1,65 @@
 export type Project = { id: string; name: string };
+export type TeamMember = { id: string; name: string };
 
 const API_BASE = process.env.SERVER_URL || 'http://localhost:3001';
 
 class HarvestStore {
   private projects: Project[] | null = null;
-  private pending: Promise<Project[]> | null = null;
+  private projectsPending: Promise<Project[]> | null = null;
+  private teamMembers: TeamMember[] | null = null;
+  private teamMembersPending: Promise<TeamMember[]> | null = null;
 
   async getProjects(): Promise<Project[]> {
     if (this.projects) {
       return Promise.resolve(this.projects);
     }
-    if (this.pending) {
-      return this.pending;
+    if (this.projectsPending) {
+      return this.projectsPending;
     }
-    this.pending = fetch(`${API_BASE}/harvest/clients`)
+    this.projectsPending = fetch(`${API_BASE}/harvest/clients`)
       .then(async (res) => {
         if (!res.ok) {
           throw new Error(`Failed to fetch projects: ${res.status}`);
         }
         const data: Project[] = await res.json();
         this.projects = data;
-        this.pending = null;
+        this.projectsPending = null;
         return data;
       })
       .catch((err) => {
-        this.pending = null;
+        this.projectsPending = null;
         throw err;
       });
-    return this.pending;
+    return this.projectsPending;
+  }
+
+  async getTeamMembers(): Promise<TeamMember[]> {
+    if (this.teamMembers) {
+      return Promise.resolve(this.teamMembers);
+    }
+    if (this.teamMembersPending) {
+      return this.teamMembersPending;
+    }
+    this.teamMembersPending = fetch(`${API_BASE}/harvest/team-members`)
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`Failed to fetch team members: ${res.status}`);
+        }
+        const data: TeamMember[] = await res.json();
+        this.teamMembers = data;
+        this.teamMembersPending = null;
+        return data;
+      })
+      .catch((err) => {
+        this.teamMembersPending = null;
+        throw err;
+      });
+    return this.teamMembersPending;
   }
 
   clearCache(): void {
     this.projects = null;
+    this.teamMembers = null;
   }
 }
 

--- a/client/src/ResourceMatrix.tsx
+++ b/client/src/ResourceMatrix.tsx
@@ -1,7 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import harvestStore, { Project } from './HarvestStore';
-
-const developers = ['Alice', 'Bob', 'Charlie'];
+import harvestStore, { Project, TeamMember } from './HarvestStore';
 
 const allocations: Record<string, Record<string, number>> = {
   Alice: { 'Project 1': 40, 'Project 2': 60 },
@@ -11,12 +9,22 @@ const allocations: Record<string, Record<string, number>> = {
 
 export default function ResourceMatrix() {
   const [projects, setProjects] = useState<Project[]>([]);
+  const [teamMembers, setTeamMembers] = useState<TeamMember[] | null>(null);
 
   useEffect(() => {
     harvestStore.getProjects().then(setProjects).catch(() => {
       setProjects([]);
     });
+    harvestStore.getTeamMembers().then(setTeamMembers).catch(() => {
+      setTeamMembers([]);
+    });
   }, []);
+
+  if (teamMembers === null) {
+    return <div>Loading...</div>;
+  }
+
+  const developers = teamMembers.map((m) => m.name);
 
   const projectNames = projects.map((p) => p.name);
   const totalsPerDeveloper = developers.map((dev) => {


### PR DESCRIPTION
## Summary
- add `TeamMember` type and caching to `HarvestStore`
- implement `getTeamMembers()` fetching `/harvest/team-members`
- use team member data in `ResourceMatrix`
- display loading fallback while team members load

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_b_6873ba58a1508322b284fbb5677a4b6f