### PR TITLE
Add allocations CRUD module

### DIFF
--- a/server/src/allocations/allocation.entity.ts
+++ b/server/src/allocations/allocation.entity.ts
@@ -1,0 +1,25 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity({ name: 'allocations' })
+export class Allocation {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  team_name: string;
+
+  @Column()
+  project_name: string;
+
+  @Column({ type: 'date' })
+  date: string;
+
+  @Column({ type: 'decimal', precision: 4, scale: 2 })
+  hours: number;
+
+  @Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+
+  @Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' })
+  updated_at: Date;
+}

--- a/server/src/allocations/allocations.controller.ts
+++ b/server/src/allocations/allocations.controller.ts
@@ -1,0 +1,35 @@
+import { Body, Controller, Delete, Get, Param, Post, Put, UsePipes, ValidationPipe } from '@nestjs/common';
+import { AllocationsService } from './allocations.service';
+import { CreateAllocationDto } from './dto/create-allocation.dto';
+import { UpdateAllocationDto } from './dto/update-allocation.dto';
+
+@Controller('allocations')
+@UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }))
+export class AllocationsController {
+  constructor(private readonly service: AllocationsService) {}
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateAllocationDto) {
+    return this.service.create(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateAllocationDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/server/src/allocations/allocations.module.ts
+++ b/server/src/allocations/allocations.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Allocation } from './allocation.entity';
+import { AllocationsService } from './allocations.service';
+import { AllocationsController } from './allocations.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Allocation])],
+  providers: [AllocationsService],
+  controllers: [AllocationsController],
+})
+export class AllocationsModule {}

--- a/server/src/allocations/allocations.service.ts
+++ b/server/src/allocations/allocations.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Allocation } from './allocation.entity';
+import { CreateAllocationDto } from './dto/create-allocation.dto';
+import { UpdateAllocationDto } from './dto/update-allocation.dto';
+
+@Injectable()
+export class AllocationsService {
+  constructor(
+    @InjectRepository(Allocation)
+    private readonly repo: Repository<Allocation>,
+  ) {}
+
+  create(dto: CreateAllocationDto) {
+    const allocation = this.repo.create(dto);
+    return this.repo.save(allocation);
+  }
+
+  findAll() {
+    return this.repo.find();
+  }
+
+  async findOne(id: string) {
+    const allocation = await this.repo.findOne({ where: { id } });
+    if (!allocation) {
+      throw new NotFoundException('Allocation not found');
+    }
+    return allocation;
+  }
+
+  async update(id: string, dto: UpdateAllocationDto) {
+    const allocation = await this.findOne(id);
+    Object.assign(allocation, dto);
+    return this.repo.save(allocation);
+  }
+
+  async remove(id: string) {
+    const allocation = await this.findOne(id);
+    await this.repo.remove(allocation);
+    return { deleted: true };
+  }
+}

--- a/server/src/allocations/dto/create-allocation.dto.ts
+++ b/server/src/allocations/dto/create-allocation.dto.ts
@@ -1,0 +1,17 @@
+import { IsDateString, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+export class CreateAllocationDto {
+  @IsString()
+  @IsNotEmpty()
+  team_name: string;
+
+  @IsString()
+  @IsNotEmpty()
+  project_name: string;
+
+  @IsDateString()
+  date: string;
+
+  @IsNumber()
+  hours: number;
+}

--- a/server/src/allocations/dto/update-allocation.dto.ts
+++ b/server/src/allocations/dto/update-allocation.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateAllocationDto } from './create-allocation.dto';
+
+export class UpdateAllocationDto extends PartialType(CreateAllocationDto) {}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { databaseProvider } from './database.provider';
 import { WorkingDaysModule } from './working-days/working-days.module';
+import { AllocationsModule } from './allocations/allocations.module';
 import { HarvestService } from './harvest/harvest.service';
 import { HarvestController } from './harvest/harvest.controller';
 
@@ -25,6 +26,7 @@ import { HarvestController } from './harvest/harvest.controller';
       },
     }),
     WorkingDaysModule,
+    AllocationsModule,
   ],
   controllers: [AppController, HarvestController],
   providers: [AppService, databaseProvider, HarvestService],

--- a/server/src/migrations/1700000000000-CreateAllocations.ts
+++ b/server/src/migrations/1700000000000-CreateAllocations.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateAllocations1700000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'allocations',
+        columns: [
+          {
+            name: 'id',
+            type: 'uniqueidentifier',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'NEWID()',
+          },
+          {
+            name: 'team_name',
+            type: 'varchar',
+          },
+          {
+            name: 'project_name',
+            type: 'varchar',
+          },
+          {
+            name: 'date',
+            type: 'date',
+          },
+          {
+            name: 'hours',
+            type: 'decimal',
+            precision: 4,
+            scale: 2,
+          },
+          {
+            name: 'created_at',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updated_at',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('allocations');
+  }
+}


### PR DESCRIPTION
## Summary
- add `Allocation` entity
- add allocations service/controller/module
- create migration for `allocations` table
- wire new module into `AppModule`

## Testing
- `npm run build` *(fails: Cannot find module 'typeorm' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6873bc6cc1dc8322a1e4df1e582d087f