### PR TITLE
Add routing with React Router

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "@nestjs/swagger": "^11.2.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { Routes, Route } from 'react-router-dom';
 import ResourceMatrix from './ResourceMatrix';
+import ProjectAllocationTable from './ProjectAllocationTable';
 import Header from './Header';
 import Footer from './Footer';
 
@@ -7,7 +9,13 @@ export default function App() {
   return (
     <div>
       <Header />
-      <ResourceMatrix />
+      <Routes>
+        <Route path="/" element={<ResourceMatrix />} />
+        <Route
+          path="/project/:projectName"
+          element={<ProjectAllocationTable />}
+        />
+      </Routes>
       <Footer />
     </div>
   );

--- a/client/src/ProjectAllocationTable.tsx
+++ b/client/src/ProjectAllocationTable.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 interface Allocation {
   id: string;
@@ -7,13 +8,9 @@ interface Allocation {
   hours: number;
 }
 
-interface Props {
-  projectName: string;
-}
-
 const API_BASE = process.env.SERVER_URL || 'http://localhost:3001';
-
-export default function ProjectAllocationTable({ projectName }: Props) {
+export default function ProjectAllocationTable() {
+  const { projectName = '' } = useParams<{ projectName?: string }>();
   const now = new Date();
   const [year, setYear] = useState(now.getFullYear());
   const [month, setMonth] = useState(now.getMonth() + 1); // 1-based

--- a/client/src/ResourceMatrix.tsx
+++ b/client/src/ResourceMatrix.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import harvestStore, { Project, TeamMember } from './HarvestStore';
 
 const allocations: Record<string, Record<string, number>> = {
@@ -68,7 +69,9 @@ export default function ResourceMatrix() {
           <tr>
             <th style={cellStyle}></th>
             {projectNames.map((project) => (
-              <th key={project} style={cellStyle}>{project}</th>
+              <th key={project} style={cellStyle}>
+                <Link to={`/project/${encodeURIComponent(project)}`}>{project}</Link>
+              </th>
             ))}
             <th style={totalStyle}>Total</th>
           </tr>

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 
 const container = document.getElementById('root');
 const root = createRoot(container);
-root.render(<App />);
+root.render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>,
+);


### PR DESCRIPTION
## Summary
- install `react-router-dom`
- enable `BrowserRouter` in the client entry
- configure routes for project and matrix views
- link project headers to their allocation pages
- get project name from the URL in `ProjectAllocationTable`

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_b_6873c0ca6f7c832283275af8ef0e128e