### PR TITLE
Fix SPA reload error

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -33,6 +33,7 @@ module.exports = {
     static: {
       directory: path.join(__dirname, 'public'),
     },
+    historyApiFallback: true,
     port: 3001,
   },
 };


### PR DESCRIPTION
## Summary
- ensure that the webpack dev server serves index.html for unknown routes

## Testing
- `npm install` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_6873ce11f62883228ea56330d44e09fc