### PR TITLE
Implement working days API

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppService } from './app.service';
 import { databaseProvider } from './database.provider';
 import { WorkingDaysModule } from './working-days/working-days.module';
 import { AllocationsModule } from './allocations/allocations.module';
+import { GlobalsModule } from './globals/globals.module';
 import { HarvestService } from './harvest/harvest.service';
 import { HarvestController } from './harvest/harvest.controller';
 
@@ -27,6 +28,7 @@ import { HarvestController } from './harvest/harvest.controller';
     }),
     WorkingDaysModule,
     AllocationsModule,
+    GlobalsModule,
   ],
   controllers: [AppController, HarvestController],
   providers: [AppService, databaseProvider, HarvestService],

--- a/server/src/globals/globals.controller.ts
+++ b/server/src/globals/globals.controller.ts
@@ -1,0 +1,21 @@
+import { BadRequestException, Controller, Get, Query } from '@nestjs/common';
+import { GlobalsService } from './globals.service';
+
+@Controller('globals')
+export class GlobalsController {
+  constructor(private readonly service: GlobalsService) {}
+
+  @Get('working-days')
+  async getWorkingDays(
+    @Query('year') year: string,
+    @Query('month') month: string,
+  ) {
+    const y = parseInt(year, 10);
+    const m = parseInt(month, 10);
+    if (isNaN(y) || isNaN(m)) {
+      throw new BadRequestException('Invalid year or month');
+    }
+    const workingDays = await this.service.getWorkingDays(y, m);
+    return { workingDays };
+  }
+}

--- a/server/src/globals/globals.module.ts
+++ b/server/src/globals/globals.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { GlobalsController } from './globals.controller';
+import { GlobalsService } from './globals.service';
+import { WorkingDayOverride } from './working-day-override.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([WorkingDayOverride])],
+  controllers: [GlobalsController],
+  providers: [GlobalsService],
+})
+export class GlobalsModule {}

--- a/server/src/globals/globals.service.ts
+++ b/server/src/globals/globals.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WorkingDayOverride } from './working-day-override.entity';
+
+@Injectable()
+export class GlobalsService {
+  constructor(
+    @InjectRepository(WorkingDayOverride)
+    private readonly overridesRepo: Repository<WorkingDayOverride>,
+  ) {}
+
+  async getWorkingDays(year: number, month: number): Promise<number[]> {
+    const daysInMonth = new Date(year, month, 0).getDate();
+    const start = new Date(year, month - 1, 1);
+    const end = new Date(year, month - 1, daysInMonth);
+    const startIso = start.toISOString().slice(0, 10);
+    const endIso = end.toISOString().slice(0, 10);
+
+    const overrides = await this.overridesRepo
+      .createQueryBuilder('o')
+      .select('o.date')
+      .where('o.date BETWEEN :start AND :end', { start: startIso, end: endIso })
+      .getMany();
+
+    const excluded = new Set(overrides.map((o) => o.date));
+    const workingDays: number[] = [];
+
+    for (let day = 1; day <= daysInMonth; day++) {
+      const date = new Date(year, month - 1, day);
+      const iso = date.toISOString().slice(0, 10);
+      const dow = date.getDay();
+      const isDefaultWorking = dow >= 0 && dow <= 4; // Sun-Thu
+      if (isDefaultWorking && !excluded.has(iso)) {
+        workingDays.push(day);
+      }
+    }
+
+    return workingDays;
+  }
+}

--- a/server/src/globals/working-day-override.entity.ts
+++ b/server/src/globals/working-day-override.entity.ts
@@ -1,0 +1,22 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity({ name: 'working_day_overrides' })
+export class WorkingDayOverride {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'date', unique: true })
+  date: string;
+
+  @Column({ nullable: true })
+  holiday_name: string | null;
+
+  @Column({ type: 'decimal', precision: 4, scale: 2 })
+  working_hours: number;
+
+  @Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+
+  @Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' })
+  updated_at: Date;
+}


### PR DESCRIPTION
## Summary
- create new globals module exposing endpoint `/globals/working-days`
- compute default working days (Sun-Thu) with overrides from `working_day_overrides`
- register `GlobalsModule` in the app

## Testing
- `npm --prefix server run build` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_6873d0117230832299cae858a959c226