### PR TITLE
Fix project filtering in allocations API

### DIFF
--- a/server/src/allocations/allocations.controller.ts
+++ b/server/src/allocations/allocations.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Post, Put, UsePipes, ValidationPipe } from '@nestjs/common';
+import { BadRequestException, Body, Controller, Delete, Get, Param, Post, Put, Query, UsePipes, ValidationPipe } from '@nestjs/common';
 import { AllocationsService } from './allocations.service';
 import { CreateAllocationDto } from './dto/create-allocation.dto';
 import { UpdateAllocationDto } from './dto/update-allocation.dto';
@@ -9,7 +9,19 @@ export class AllocationsController {
   constructor(private readonly service: AllocationsService) {}
 
   @Get()
-  findAll() {
+  findAll(
+    @Query('project') project?: string,
+    @Query('year') year?: string,
+    @Query('month') month?: string,
+  ) {
+    if (project && year && month) {
+      const y = parseInt(year, 10);
+      const m = parseInt(month, 10);
+      if (isNaN(y) || isNaN(m)) {
+        throw new BadRequestException('Invalid year or month');
+      }
+      return this.service.findByProjectAndMonth(project, y, m);
+    }
     return this.service.findAll();
   }
 

--- a/server/src/allocations/allocations.service.ts
+++ b/server/src/allocations/allocations.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Between, Repository } from 'typeorm';
 import { Allocation } from './allocation.entity';
 import { CreateAllocationDto } from './dto/create-allocation.dto';
 import { UpdateAllocationDto } from './dto/update-allocation.dto';
@@ -19,6 +19,18 @@ export class AllocationsService {
 
   findAll() {
     return this.repo.find();
+  }
+
+  findByProjectAndMonth(project: string, year: number, month: number) {
+    const start = new Date(year, month - 1, 1).toISOString().slice(0, 10);
+    const end = new Date(year, month, 0).toISOString().slice(0, 10);
+    return this.repo.find({
+      where: {
+        project_name: project,
+        date: Between(start, end),
+      },
+      order: { date: 'ASC' },
+    });
   }
 
   async findOne(id: string) {


### PR DESCRIPTION
## Summary
- handle `project`, `year`, and `month` query params in allocations controller
- add `findByProjectAndMonth` method to service for date range filtering

## Testing
- `npm run build` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_b_6874f5e662b883228819d9ffa9fa5610