### PR TITLE
Add range-based allocation support

### DIFF
--- a/server/src/allocations/allocation.entity.ts
+++ b/server/src/allocations/allocation.entity.ts
@@ -12,10 +12,12 @@ export class Allocation {
   project_name: string;
 
   @Column({ type: 'date' })
-  date: string;
+  start_date: string;
 
-  @Column({ type: 'decimal', precision: 4, scale: 2 })
-  hours: number;
+  @Column({ type: 'date' })
+  end_date: string;
+  @Column({ type: 'decimal', precision: 4, scale: 2, nullable: true })
+  hours: number | null;
 
   @Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   created_at: Date;

--- a/server/src/allocations/allocations.service.ts
+++ b/server/src/allocations/allocations.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Between, Repository } from 'typeorm';
+import { Repository, LessThanOrEqual, MoreThanOrEqual } from 'typeorm';
 import { Allocation } from './allocation.entity';
 import { CreateAllocationDto } from './dto/create-allocation.dto';
 import { UpdateAllocationDto } from './dto/update-allocation.dto';
@@ -27,9 +27,10 @@ export class AllocationsService {
     return this.repo.find({
       where: {
         project_name: project,
-        date: Between(start, end),
+        start_date: LessThanOrEqual(end),
+        end_date: MoreThanOrEqual(start),
       },
-      order: { date: 'ASC' },
+      order: { start_date: 'ASC' },
     });
   }
 

--- a/server/src/allocations/dto/create-allocation.dto.ts
+++ b/server/src/allocations/dto/create-allocation.dto.ts
@@ -1,4 +1,4 @@
-import { IsDateString, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { IsDateString, IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class CreateAllocationDto {
   @IsString()
@@ -10,8 +10,11 @@ export class CreateAllocationDto {
   project_name: string;
 
   @IsDateString()
-  date: string;
+  start_date: string;
 
+  @IsDateString()
+  end_date: string;
+  @IsOptional()
   @IsNumber()
-  hours: number;
+  hours?: number;
 }


### PR DESCRIPTION
## Summary
- support start_date and end_date in allocation DTO and entity
- adjust allocation service to filter by date range
- update frontend to send and display date ranges

## Testing
- `npm run build` *(fails: Cannot find module ...)*
- `npm run build` in client *(fails: Cannot find module ...)*

------
https://chatgpt.com/codex/tasks/task_b_6875168f62908322ab93ec91ae215622