### PR TITLE
Make project filter optional for allocations

### DIFF
--- a/server/src/allocations/allocations.controller.ts
+++ b/server/src/allocations/allocations.controller.ts
@@ -14,13 +14,16 @@ export class AllocationsController {
     @Query('year') year?: string,
     @Query('month') month?: string,
   ) {
-    if (project && year && month) {
+    if (year && month) {
       const y = parseInt(year, 10);
       const m = parseInt(month, 10);
       if (isNaN(y) || isNaN(m)) {
         throw new BadRequestException('Invalid year or month');
       }
-      return this.service.findByProjectAndMonth(project, y, m);
+      if (project) {
+        return this.service.findByProjectAndMonth(project, y, m);
+      }
+      return this.service.findByMonth(y, m);
     }
     return this.service.findAll();
   }

--- a/server/src/allocations/allocations.service.ts
+++ b/server/src/allocations/allocations.service.ts
@@ -34,6 +34,18 @@ export class AllocationsService {
     });
   }
 
+  findByMonth(year: number, month: number) {
+    const start = new Date(year, month - 1, 1).toISOString().slice(0, 10);
+    const end = new Date(year, month, 0).toISOString().slice(0, 10);
+    return this.repo.find({
+      where: {
+        start_date: LessThanOrEqual(end),
+        end_date: MoreThanOrEqual(start),
+      },
+      order: { start_date: 'ASC' },
+    });
+  }
+
   async findOne(id: string) {
     const allocation = await this.repo.findOne({ where: { id } });
     if (!allocation) {


### PR DESCRIPTION
## Summary
- allow filtering allocations by month without specifying a project
- support retrieving allocations from all projects when no project is provided

## Testing
- `npm run build` *(fails: cannot find module dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68760d28e9608322856e245e424a3d95