### PR TITLE
Add allocation fetching to ResourceMatrix

### DIFF
--- a/client/src/ResourceMatrix.tsx
+++ b/client/src/ResourceMatrix.tsx
@@ -2,17 +2,26 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import harvestStore, { Project, TeamMember } from './stores/HarvestStore';
 
-const allocations: Record<string, Record<string, number>> = {
-  Alice: { 'Project 1': 40, 'Project 2': 60 },
-  Bob: { 'Project 1': 50, 'Project 2': 30 },
-  Charlie: { 'Project 1': 20, 'Project 2': 40 },
-};
+interface Allocation {
+  id: string;
+  team_name: string;
+  project_name: string;
+  start_date: string;
+  end_date: string;
+  hours: number | null;
+}
+
+const API_BASE = process.env.SERVER_URL || 'http://localhost:3001';
 
 export default function ResourceMatrix() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [teamMembers, setTeamMembers] = useState<TeamMember[] | null>(null);
   const navigate = useNavigate();
   const [hoveredProject, setHoveredProject] = useState<string | null>(null);
+  const [selectedMonth, setSelectedMonth] = useState(
+    new Date().toISOString().slice(0, 7),
+  );
+  const [allocations, setAllocations] = useState<Allocation[]>([]);
 
   useEffect(() => {
     harvestStore.getProjects().then(setProjects).catch(() => {
@@ -23,6 +32,28 @@ export default function ResourceMatrix() {
     });
   }, []);
 
+  useEffect(() => {
+    const abort = new AbortController();
+    const [year, month] = selectedMonth.split('-').map(Number);
+    fetch(`${API_BASE}/allocations?year=${year}&month=${month}`, {
+      signal: abort.signal,
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`Failed to fetch allocations: ${res.status}`);
+        }
+        const data: Allocation[] = await res.json();
+        setAllocations(data);
+      })
+      .catch((err) => {
+        if (err.name !== 'AbortError') {
+          console.error(err);
+          setAllocations([]);
+        }
+      });
+    return () => abort.abort();
+  }, [selectedMonth]);
+
   if (teamMembers === null) {
     return <div>Loading...</div>;
   }
@@ -30,16 +61,28 @@ export default function ResourceMatrix() {
   const developers = teamMembers.map((m) => m.name);
 
   const projectNames = projects.map((p) => p.name);
+  const allocationMap: Record<string, Record<string, number>> = {};
+  allocations.forEach((a) => {
+    const start = new Date(a.start_date);
+    const end = new Date(a.end_date);
+    const days =
+      Math.floor((end.getTime() - start.getTime()) / 86400000) + 1;
+    const hours = (a.hours ?? 8) * days;
+    if (!allocationMap[a.team_name]) allocationMap[a.team_name] = {};
+    allocationMap[a.team_name][a.project_name] =
+      (allocationMap[a.team_name][a.project_name] || 0) + hours;
+  });
+
   const totalsPerDeveloper = developers.map((dev) => {
     return projectNames.reduce(
-      (sum, proj) => sum + (allocations[dev]?.[proj] || 0),
+      (sum, proj) => sum + (allocationMap[dev]?.[proj] || 0),
       0,
     );
   });
 
   const totalsPerProject = projectNames.map((proj) => {
     return developers.reduce(
-      (sum, dev) => sum + (allocations[dev]?.[proj] || 0),
+      (sum, dev) => sum + (allocationMap[dev]?.[proj] || 0),
       0,
     );
   });
@@ -71,6 +114,13 @@ export default function ResourceMatrix() {
   return (
     <div>
       <center><h2>Resource Allocation Matrix</h2></center>
+      <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '8px' }}>
+        <input
+          type="month"
+          value={selectedMonth}
+          onChange={(e) => setSelectedMonth(e.target.value)}
+        />
+      </div>
       <table style={tableStyle}>
         <thead>
           <tr>
@@ -98,7 +148,7 @@ export default function ResourceMatrix() {
             <tr key={dev}>
               <td style={cellStyle}>{dev}</td>
               {projectNames.map((proj) => (
-                <td key={proj} style={cellStyle}>{allocations[dev]?.[proj] || 0}</td>
+                <td key={proj} style={cellStyle}>{allocationMap[dev]?.[proj] || 0}</td>
               ))}
               <td style={totalStyle}>{totalsPerDeveloper[idx]}</td>
             </tr>


### PR DESCRIPTION
## Summary
- remove stub data in `ResourceMatrix`
- add month selector
- fetch allocations from backend when page loads and when month changes

## Testing
- `npm run build --prefix client` *(fails: webpack not found)*
- `npm run build --prefix server` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_b_68765e4b92408322a5d76f6d14937c66