### PR TITLE
Improve weekly plan headers and navigation

### DIFF
--- a/client/src/ProjectAllocationTable.tsx
+++ b/client/src/ProjectAllocationTable.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useMemo, useState} from 'react';
-import {useParams} from 'react-router-dom';
+import {useParams, useLocation} from 'react-router-dom';
 import harvestStore, {TeamMember} from './stores/HarvestStore';
 import globalStore from './stores/GlobalStore';
 
@@ -15,9 +15,13 @@ interface Allocation {
 const API_BASE = process.env.SERVER_URL || 'http://localhost:3001';
 export default function ProjectAllocationTable() {
     const {projectName = ''} = useParams<{ projectName?: string }>();
+    const {search} = useLocation();
+    const params = new URLSearchParams(search);
     const now = new Date();
-    const [year, setYear] = useState(now.getFullYear());
-    const [month, setMonth] = useState(now.getMonth() + 1); // 1-based
+    const initYear = Number(params.get('year')) || now.getFullYear();
+    const initMonth = Number(params.get('month')) || now.getMonth() + 1;
+    const [year, setYear] = useState(initYear);
+    const [month, setMonth] = useState(initMonth); // 1-based
     const [allocations, setAllocations] = useState<Allocation[]>([]);
     const [showModal, setShowModal] = useState(false);
     const [editingAllocation, setEditingAllocation] = useState<Allocation | null>(null);
@@ -31,6 +35,14 @@ export default function ProjectAllocationTable() {
     );
     const [startDate, setStartDate] = useState('');
     const [endDate, setEndDate] = useState('');
+
+    useEffect(() => {
+        const paramsUpdate = new URLSearchParams(search);
+        const y = Number(paramsUpdate.get('year'));
+        const m = Number(paramsUpdate.get('month'));
+        if (y) setYear(y);
+        if (m) setMonth(m);
+    }, [search]);
 
     const monthNames = [
         'January',

--- a/client/src/WeeklyPlan.tsx
+++ b/client/src/WeeklyPlan.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import harvestStore, { TeamMember } from './stores/HarvestStore';
 
 interface Allocation {
@@ -38,6 +39,7 @@ function getWeekStartEnd(value: string) {
 }
 
 export default function WeeklyPlan() {
+  const navigate = useNavigate();
   const [teamMembers, setTeamMembers] = useState<TeamMember[] | null>(null);
   const [selectedWeek, setSelectedWeek] = useState(isoWeekString(new Date()));
   const [allocations, setAllocations] = useState<Allocation[]>([]);
@@ -120,8 +122,10 @@ export default function WeeklyPlan() {
         <thead>
           <tr>
             <th style={cellStyle}></th>
-            {dayNames.map((d) => (
-              <th key={d} style={cellStyle}>{d}</th>
+            {days.map(({ date }, idx) => (
+              <th key={idx} style={cellStyle}>
+                {dayNames[idx]} {date.getDate()}
+              </th>
             ))}
           </tr>
         </thead>
@@ -129,9 +133,25 @@ export default function WeeklyPlan() {
           {developers.map((dev) => (
             <tr key={dev}>
               <td style={cellStyle}>{dev}</td>
-              {days.map(({ key }) => (
+              {days.map(({ key, date }) => (
                 <td key={key} style={cellStyle}>
-                  {(dailyMap[dev]?.[key] || []).join(', ')}
+                  {(dailyMap[dev]?.[key] || []).map((proj) => (
+                    <div
+                      key={proj}
+                      style={{
+                        cursor: 'pointer',
+                        textDecoration: 'underline',
+                        color: '#007bff',
+                      }}
+                      onClick={() =>
+                        navigate(
+                          `/project/${encodeURIComponent(proj)}?year=${date.getFullYear()}&month=${date.getMonth() + 1}`,
+                        )
+                      }
+                    >
+                      {proj}
+                    </div>
+                  ))}
                 </td>
               ))}
             </tr>


### PR DESCRIPTION
## Summary
- show the date next to the weekday label in WeeklyPlan header
- make project names in the weekly table clickable
- allow `ProjectAllocationTable` to read year/month from query params

## Testing
- `npm run build` in `client` *(fails: webpack not found)*
- `npm run build` in `server` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_687675f3dc1883229eabd8c5d52bd676